### PR TITLE
update state on pages where the hint should not be displayed

### DIFF
--- a/theme/validity-theme/functions.php
+++ b/theme/validity-theme/functions.php
@@ -138,6 +138,17 @@ function validity_scripts() {
 
 	wp_enqueue_script('validity_app');
 
+	if ( is_page( 'resources' ) || is_page( 'take-action' ) ) {
+		wp_register_script( 'hide-hint', get_template_directory_uri() . '/js/hide-hint.js', 'validity_require');
+		wp_enqueue_script('hide-hint');
+	}
+
+
+	// if (is_page('/') || is_page('donation') || is_page('im-a-person')) {
+	// 	wp_register_script( 'display-hint', get_template_directory_uri() . '/js/display-hint.js', 'validity_require');
+	// 	wp_enqueue_script('display-hint');
+	// };
+
 	// if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 	// 	wp_enqueue_script( 'comment-reply' );
 	// }

--- a/theme/validity-theme/header.php
+++ b/theme/validity-theme/header.php
@@ -17,11 +17,13 @@
 		<title>Validity</title>
 		<meta name="viewport" content="width=device-width initial-scale=1.0">
 		<script src="<?php echo get_stylesheet_directory_uri(); ?>/js/require.js" data-main="<?php echo get_stylesheet_directory_uri(); ?>/js/app.js"></script>
+
 		<script>
-			var settings = {
-				animate 	: true,
-				showHint	: true
-			};
+				var settings = {
+					animate 	: true,
+					showHint	: true
+				};
 		</script>
+
     <?php wp_head(); ?>
 	</head>

--- a/theme/validity-theme/js/hide-hint.js
+++ b/theme/validity-theme/js/hide-hint.js
@@ -1,0 +1,4 @@
+var settings = {
+  animate 	: true,
+  showHint	: false
+};


### PR DESCRIPTION
the state for 'showHint' was being set to true for every page, as the script was loaded in the header. 

The script is still loaded in header, with the addition of a new 'hide-hint' script, which is called on pages where it should not be displayed (via validity_scripts() in functions.php)

fixes #57